### PR TITLE
Add psutil dependency to rct_horror_mod

### DIFF
--- a/rct_horror_mod/requirements.txt
+++ b/rct_horror_mod/requirements.txt
@@ -1,2 +1,3 @@
 pefile
 pillow
+psutil


### PR DESCRIPTION
If we attempt to run rct_horror_mod.py without installing the `psutil` package we get:
```
ModuleNotFoundError: No module named 'psutil'
```
We basically add `psutil` to `requirements.txt`.
(Also, offtopic but when are you planning to release the video?)